### PR TITLE
Fix Android build by pinning react-native-contacts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "contact-app",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
         "@react-native-async-storage/async-storage": "2.1.2",
@@ -29,7 +30,7 @@
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.5",
-        "react-native-contacts": "^8.0.5",
+        "react-native-contacts": "8.0.5",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-get-random-values": "^1.11.0",
         "react-native-reanimated": "~3.17.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.5",
-    "react-native-contacts": "^8.0.5",
+    "react-native-contacts": "8.0.5",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-get-random-values": "^1.11.0",
     "react-native-reanimated": "~3.17.4",


### PR DESCRIPTION
## Summary
- pin `react-native-contacts` to version 8.0.5

Android build failed because the patch in `patches/react-native-contacts+8.0.5.patch`
only applies to v8.0.5. Without the exact version, a newer release may install
and miss patched native methods like `removeContactsFromGroup`.

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_688c0d8007748320ba963bc3599a8f6f